### PR TITLE
Handle incomplete ChatGPT runs

### DIFF
--- a/Code/URL_input.py
+++ b/Code/URL_input.py
@@ -61,16 +61,18 @@ def ChatGPT(apikey,inputtext):
 
   print("ChatGPR Run completed with status: " + run.status)
 
-  if run.status == "completed":
-    messages = client.beta.threads.messages.list(thread_id=thread.id)
-    # print("messages: ")
-    # for message in messages:
-    #     assert message.content[0].type == "text"
-    #     print({"role": message.role, "message": message.content[0].text.value})
-  else:
-    print("Futasi hiba: ",run.status)      
+  if run.status != "completed":
+    print("Futasi hiba: ", run.status)
+    client.beta.assistants.delete(assistant.id)
+    return None
 
-  vissza=messages.data[0].content[0].text.value
+  messages = client.beta.threads.messages.list(thread_id=thread.id)
+  # print("messages: ")
+  # for message in messages:
+  #     assert message.content[0].type == "text"
+  #     print({"role": message.role, "message": message.content[0].text.value})
+
+  vissza = messages.data[0].content[0].text.value
   client.beta.assistants.delete(assistant.id)
   return vissza
 

--- a/Code/YANAC-Osszegzo.py
+++ b/Code/YANAC-Osszegzo.py
@@ -92,16 +92,18 @@ def ChatGPT(apikey,inputtext):
 
   print("ChatGPR Run completed with status: " + run.status)
 
-  if run.status == "completed":
-    messages = client.beta.threads.messages.list(thread_id=thread.id)
-    # print("messages: ")
-    # for message in messages:
-    #     assert message.content[0].type == "text"
-    #     print({"role": message.role, "message": message.content[0].text.value})
-  else:
-    print(run.status)      
+  if run.status != "completed":
+    print(run.status)
+    client.beta.assistants.delete(assistant.id)
+    return None
 
-  vissza=messages.data[0].content[0].text.value
+  messages = client.beta.threads.messages.list(thread_id=thread.id)
+  # print("messages: ")
+  # for message in messages:
+  #     assert message.content[0].type == "text"
+  #     print({"role": message.role, "message": message.content[0].text.value})
+
+  vissza = messages.data[0].content[0].text.value
   client.beta.assistants.delete(assistant.id)
   return vissza
 


### PR DESCRIPTION
## Summary
- Avoid undefined `messages` when ChatGPT run fails by returning early
- Apply the same fix to text summarizer script

## Testing
- `python -m py_compile Code/URL_input.py Code/YANAC-Osszegzo.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8c0bcdfbc83288d25e0b1402baf64