### PR TITLE
Ensure fordito returns translated text string

### DIFF
--- a/Code/YANAC-Osszegzo.py
+++ b/Code/YANAC-Osszegzo.py
@@ -153,7 +153,7 @@ def fordito(key,szoveg): # Fordito function, calls DEEPL to translate the text.
 
     result = translator.translate_text(text=szoveg, target_lang="HU", formality="prefer_more")
     # print("Fordito lefutott")
-    return result
+    return result.text
 
 
 ##########################################


### PR DESCRIPTION
## Summary
- Fix translation helper to return the raw translated string instead of the full response object.

## Testing
- `python -m py_compile Code/YANAC-Osszegzo.py`
- `python - <<'PY'
import sys, types, ast
code = open('Code/YANAC-Osszegzo.py').read()
module_ast = ast.parse(code)
fordito_source = [node for node in module_ast.body if isinstance(node, ast.FunctionDef) and node.name == 'fordito'][0]
namespace = {}
exec(compile(ast.Module([fordito_source], []), filename='', mode='exec'), namespace)
fordito = namespace['fordito']

class DummyResult:
    def __init__(self, text):
        self.text = text

class DummyTranslator:
    def __init__(self, auth_key):
        self.auth_key = auth_key
    def translate_text(self, text, target_lang, formality):
        return DummyResult(f"translated({text})")

sys.modules['deepl'] = types.SimpleNamespace(Translator=DummyTranslator)
print(fordito(['dummy','key'], 'hello world'))
print(type(fordito(['dummy','key'], 'hello world')))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a8c77eb9e48328af3d1e6d630462b3